### PR TITLE
Switch submodules to https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "json-fortran"]
 	path = json-fortran
-	url = git@github.com:jonathanschilling/json-fortran.git
+	url = https://github.com/jonathanschilling/json-fortran.git
 [submodule "LIBSTELL"]
 	path = LIBSTELL
-	url = git@github.com:ORNL-Fusion/LIBSTELL.git
+	url = https://github.com/ORNL-Fusion/LIBSTELL.git


### PR DESCRIPTION
So we can clone the repo without ssh credentials.